### PR TITLE
Contributor gravatar id fix [DNM]

### DIFF
--- a/app/models/concerns/user/github_concern.rb
+++ b/app/models/concerns/user/github_concern.rb
@@ -10,7 +10,7 @@ module User::GithubConcern
       User.where(:uid => contributor.id.to_s).first_or_initialize do |u|
         u.name = contributor.login
         u.nickname = contributor.login
-        u.image = contributor.avatar_url
+        u.gravatar_id = contributor.gravatar_id
 
         # where is the email?! see: http://developer.github.com/v3/users/emails/
         #u.email = contributor.login

--- a/app/models/concerns/user/gravatar_concern.rb
+++ b/app/models/concerns/user/gravatar_concern.rb
@@ -1,0 +1,9 @@
+module User::GravatarConcern
+  extend ActiveSupport::Concern
+
+  # see: http://en.gravatar.com/site/implement/images/
+  def gravatar
+    "http://www.gravatar.com/avatar/#{gravatar_id}"
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,12 +1,21 @@
 class User < ActiveRecord::Base
 
   include User::GithubConcern
+  include User::GravatarConcern
 
   has_and_belongs_to_many :projects
   has_many :posts, :dependent => :destroy
 
   def nickname
     self[:nickname] || self[:name]
+  end
+
+  def image
+    if gravatar_id.present?
+      gravatar
+    else
+      self[:image]
+    end
   end
 
 end

--- a/db/migrate/20130807141934_add_gravatar_id.rb
+++ b/db/migrate/20130807141934_add_gravatar_id.rb
@@ -1,0 +1,5 @@
+class AddGravatarId < ActiveRecord::Migration
+  def change
+    add_column :users, :gravatar_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130731084038) do
+ActiveRecord::Schema.define(version: 20130807141934) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 20130731084038) do
     t.string   "email"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "gravatar_id"
   end
 
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -45,7 +45,7 @@ FactoryGirl.define do
 
     sequence(:id)  { |n| "#{n+1}#{n+2}" } #github's uid
     login       'new-user-nickname'
-    avatar_url  'http://new-user.avatar-url.com'
+    gravatar_id '5d38ab152e1e3e219512a9859fcd93af'
 
     initialize_with { Hashie::Mash.new(attributes) }
   end

--- a/spec/models/concerns/user/github_concern_spec.rb
+++ b/spec/models/concerns/user/github_concern_spec.rb
@@ -23,8 +23,8 @@ describe User::GithubConcern do
 
       let(:uid) { '1234563' }
       let(:login) { 'my-new-user-login' }
-      let(:avatar_url) { 'http://some-avatar.url.com' }
-      let(:new_contributor) { create(:github_contributor, id: uid, login: login, avatar_url: avatar_url) }
+      let(:gravatar_id) { '5d38ab152e1e3e219512a9859fcd93af' }
+      let(:new_contributor) { create(:github_contributor, id: uid, login: login, gravatar_id: gravatar_id) }
 
       let(:github_contributor) { new_contributor }
 
@@ -35,7 +35,8 @@ describe User::GithubConcern do
       its(:uid){ should eq uid }
       its(:name){ should eq login }
       its(:nickname){ should eq login }
-      its(:image){ should eq avatar_url }
+      its(:gravatar_id){ should eq gravatar_id }
+      its(:image){ should eq subject.gravatar }
 
     end
 

--- a/spec/services/github/grabber_spec.rb
+++ b/spec/services/github/grabber_spec.rb
@@ -59,12 +59,12 @@ describe Github::Grabber do
   describe :contributors do
     let(:project_name) { 'rspec/rspec' }
     let(:contributor_name) { 'dchelimsky' }
-    let(:contributor_avatar_url) { 'https://secure.gravatar.com/avatar/5d38ab152e1e3e219512a9859fcd93af?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png' }
+    let(:contributor_gravatar_id) { '5d38ab152e1e3e219512a9859fcd93af' }
 
     it "fetches the project's contributors", :vcr do
       contributors = subject.contributors
       contributors.first.login.should eq contributor_name
-      contributors.first.avatar_url.should eq contributor_avatar_url
+      contributors.first.gravatar_id.should eq contributor_gravatar_id
       contributors.should have(7).contributors
     end
   end


### PR DESCRIPTION
github no longer pass the user avatar url - only the gravatar_id

this is only relevant to the new octokit > 2
